### PR TITLE
Recurse over all points

### DIFF
--- a/src/main/kotlin/H3Writer.kt
+++ b/src/main/kotlin/H3Writer.kt
@@ -11,7 +11,7 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
     private val edgeLength = h3Core.edgeLength(h3Depth, LengthUnit.m)
     private val planet = Planet(seed = seed, resolution = (edgeLength * 0.6).roundToInt())
 
-    private fun pointToGeoJSONFeature(point: Point): JSONObject {
+    private fun toGeoJSONFeature(point: Point): JSONObject {
         val properties = JSONObject()
         properties["alt"] = point.alt
 
@@ -56,7 +56,7 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
 
         val features = JSONArray()
         for (point in finishedPoints){
-            val feature = pointToGeoJSONFeature(point)
+            val feature = toGeoJSONFeature(point)
             features.add(feature)
         }
         val featureCollection = JSONObject()

--- a/src/main/kotlin/H3Writer.kt
+++ b/src/main/kotlin/H3Writer.kt
@@ -1,7 +1,6 @@
 package com.eliottgray.kotlin
 import com.uber.h3core.H3Core
 import com.uber.h3core.LengthUnit
-import com.uber.h3core.util.GeoCoord
 import org.json.simple.JSONArray
 import org.json.simple.JSONObject
 import java.io.File
@@ -11,29 +10,6 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
     private val h3Core: H3Core = H3Core.newInstance()
     private val edgeLength = h3Core.edgeLength(h3Depth, LengthUnit.m)
     private val planet = Planet(seed = seed, resolution = (edgeLength * 0.6).roundToInt())
-
-    private fun toGeoJSONFeature(h3Node: Long): JSONObject {
-        val geo: GeoCoord = h3Core.h3ToGeo(h3Node)
-        val elevation = planet.getElevationAt(lat=geo.lat, lon=geo.lng)
-        val properties = JSONObject()
-        properties["h3"] = h3Node
-        properties["alt"] = elevation
-
-        val coordinates = JSONArray()
-        coordinates.add(geo.lng)
-        coordinates.add(geo.lat)
-
-        val geometry = JSONObject()
-        geometry["type"] = "Point"
-        geometry["coordinates"] = coordinates
-
-        val feature = JSONObject()
-        feature["type"] = "Feature"
-        feature["properties"] = properties
-        feature["geometry"] = geometry
-
-        return feature
-    }
 
     private fun pointToGeoJSONFeature(point: Point): JSONObject {
         val properties = JSONObject()
@@ -53,17 +29,6 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
         feature["geometry"] = geometry
 
         return feature
-    }
-    private fun recursiveCollect(current: Long, depth: Int, features: JSONArray) {
-        if (depth >= h3Depth){
-            features.add(toGeoJSONFeature(current))
-        } else {
-            val newDepth = depth + 1
-            val children = h3Core.h3ToChildren(current, newDepth)
-            for (child in children){
-                recursiveCollect(child, newDepth, features)
-            }
-        }
     }
 
     fun collectAndWrite(filepath: String){

--- a/src/main/kotlin/H3Writer.kt
+++ b/src/main/kotlin/H3Writer.kt
@@ -35,6 +35,25 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
         return feature
     }
 
+    private fun pointToGeoJSONFeature(point: Point): JSONObject {
+        val properties = JSONObject()
+        properties["alt"] = point.alt
+
+        val coordinates = JSONArray()
+        coordinates.add(point.lon)
+        coordinates.add(point.lat)
+
+        val geometry = JSONObject()
+        geometry["type"] = "Point"
+        geometry["coordinates"] = coordinates
+
+        val feature = JSONObject()
+        feature["type"] = "Feature"
+        feature["properties"] = properties
+        feature["geometry"] = geometry
+
+        return feature
+    }
     private fun recursiveCollect(current: Long, depth: Int, features: JSONArray) {
         if (depth >= h3Depth){
             features.add(toGeoJSONFeature(current))
@@ -49,24 +68,31 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
 
     fun collectAndWrite(filepath: String){
         val res0 = h3Core.res0Indexes
+        val children = ArrayList<Long>()
+        for (res0Node in res0) {
+            children.addAll(h3Core.h3ToChildren(res0Node, h3Depth))
+        }
+        val allPoints = ArrayList(children.map {
+            val geo = h3Core.h3ToGeo(it)
+            Point.fromSpherical(lat = geo.lat, lon = geo.lng)
+        })
+
+        // TODO: handle errors related to IO.
+
+
+        val finishedPoints = planet.getH3Elevations(allPoints)
+
         val file = File(filepath)
         if (file.exists()){
             file.delete()
         }
-        // TODO: handle errors related to IO.
-        // TODO: File should not exist before writing, since write will append text repeatedly.
 
-        // TODO: Avoid having to collect everything into memory at once.
-
-        val features = JSONArray()
-        for (index in res0) {
-            recursiveCollect(index, 0, features)
+        val bufferedWriter = file.bufferedWriter()
+        for (point in finishedPoints){
+            val feature = pointToGeoJSONFeature(point)
+            bufferedWriter.write(feature.toJSONString())
+            bufferedWriter.write("\n")
         }
-
-        val featureCollection = JSONObject()
-        featureCollection["type"] = "FeatureCollection"
-        featureCollection["features"] = features
-
-        file.writeText(featureCollection.toJSONString())
+        bufferedWriter.close()
     }
 }

--- a/src/main/kotlin/H3Writer.kt
+++ b/src/main/kotlin/H3Writer.kt
@@ -88,11 +88,17 @@ class H3Writer(val h3Depth: Int, val seed: Double = Defaults.SEED) {
         }
 
         val bufferedWriter = file.bufferedWriter()
+
+        val features = JSONArray()
         for (point in finishedPoints){
             val feature = pointToGeoJSONFeature(point)
-            bufferedWriter.write(feature.toJSONString())
-            bufferedWriter.write("\n")
+            features.add(feature)
         }
+        val featureCollection = JSONObject()
+        featureCollection["type"] = "FeatureCollection"
+        featureCollection["features"] = features
+
+        bufferedWriter.write(featureCollection.toJSONString())
         bufferedWriter.close()
     }
 }

--- a/src/main/kotlin/Planet.kt
+++ b/src/main/kotlin/Planet.kt
@@ -60,5 +60,4 @@ class Planet(val seed: Double = Defaults.SEED, val resolution: Int = Defaults.RE
     fun getH3Elevations(h3Nodes: ArrayList<Point>): ArrayList<Point> {
         return recursiveGetH3Elevations(h3Nodes, this.tetra)
     }
-
 }

--- a/src/main/kotlin/Planet.kt
+++ b/src/main/kotlin/Planet.kt
@@ -26,4 +26,39 @@ class Planet(val seed: Double = Defaults.SEED, val resolution: Int = Defaults.RE
         }
         return current.averageAltitude
     }
+
+    private fun recursiveGetH3Elevations(points: ArrayList<Point>, current: Tetrahedron): ArrayList<Point> {
+        if (points.isEmpty()){
+            return points
+        }
+        if (current.longestSide > resolution) {
+            val (leftTetra, rightTetra) = current.subdivide()
+            // TODO: Avoid needing to create an arrayList for each tetrahedron created. Expensive!
+            val leftNodes = ArrayList<Point>()
+            val rightNodes = ArrayList<Point>()
+            for (point in points) {
+                if (leftTetra.contains(point)){
+                    leftNodes.add(point)
+                } else {
+                    assert(rightTetra.contains(point))  // TODO: only enable during testing, or not have this at all.
+                    rightNodes.add(point)
+                }
+            }
+            val results = recursiveGetH3Elevations(leftNodes, leftTetra)
+            results.addAll(recursiveGetH3Elevations(rightNodes, rightTetra))
+            return results
+        } else {
+            val elevation = current.averageAltitude
+            for (point in points) {
+                // While it is often better to avoid side effects, this way we reuse the current object.
+                point.alt = elevation
+            }
+            return points
+        }
+    }
+
+    fun getH3Elevations(h3Nodes: ArrayList<Point>): ArrayList<Point> {
+        return recursiveGetH3Elevations(h3Nodes, this.tetra)
+    }
+
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -5,7 +5,7 @@ import kotlin.system.measureTimeMillis
 fun main(args: Array<String>) {
     val timeMillis = measureTimeMillis {
         val writer = H3Writer(h3Depth=3, seed=0.33234034)
-        writer.collectAndWrite("test_geojson_out.json")
+        writer.collectAndWrite("test_geojson_out.jsonl")
     }
     print(timeMillis)
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -5,7 +5,7 @@ import kotlin.system.measureTimeMillis
 fun main(args: Array<String>) {
     val timeMillis = measureTimeMillis {
         val writer = H3Writer(h3Depth=3, seed=0.33234034)
-        writer.collectAndWrite("test_geojson_out.jsonl")
+        writer.collectAndWrite("test_geojson_out.json")
     }
     print(timeMillis)
 }


### PR DESCRIPTION
Avoid subdividing a tetrahedron more than once, by passing all points into recursion.
This uses more memory (all points in memory at once) but points are fairly lightweight, and subdivision is expensive.