### PR TITLE
Fix tetrahedron point-reordering bug.

### DIFF
--- a/src/main/kotlin/Tetrahedron.kt
+++ b/src/main/kotlin/Tetrahedron.kt
@@ -5,52 +5,52 @@ data class Tetrahedron(var a: Point, var b: Point, var c: Point, var d: Point) {
     val longestSide: Double by lazy {
         val ab = this.a.distance(this.b)
         val ac = this.a.distance(this.c)
-        var longest: Double
-        var e1: Point
-        var e2: Point
-        var n1: Point
-        var n2: Point
-        if (ab >= ac){
-            longest = ab
-            e1 = this.a
-            e2 = this.b
-            n1 = this.c
-            n2 = this.d
-        } else{
-            longest = ac
+        val ad = this.a.distance(this.d)
+        val bc = this.b.distance(this.c)
+        val bd = this.b.distance(this.d)
+        val cd = this.c.distance(this.d)
+
+
+        var longest: Double = ab
+        if (ac > longest) longest = ac
+        if (ad > longest) longest = ad
+        if (bc > longest) longest = bc
+        if (bd > longest) longest = bd
+        if (cd > longest) longest = cd
+
+        var e1: Point = this.a
+        var e2: Point = this.b
+        var n1: Point = this.c
+        var n2: Point = this.d
+        if (ac == longest) {
             e1 = this.a
             e2 = this.c
             n1 = this.b
             n2 = this.d
         }
-        val ad = this.a.distance(this.d)
-        if (ad > longest){
-            longest = ad
+
+        if (ad == longest) {
             e1 = this.a
             e2 = this.d
             n1 = this.b
             n2 = this.c
         }
-        val bc = this.b.distance(this.c)
-        if (bc > longest) {
-            longest = bc
+
+        if (bc == longest){
             e1 = this.b
             e2 = this.c
             n1 = this.a
             n2 = this.d
         }
 
-        val bd = this.b.distance(this.d)
-        if (bd > longest){
-            longest = bd
+        if (bd == longest){
             e1 = this.b
-            e2 = this.c
+            e2 = this.d
             n1 = this.a
-            n2 = this.d
+            n2 = this.c
         }
-        val cd = this.c.distance(this.d)
-        if (cd > longest){
-            longest = cd
+
+        if (cd == longest){
             e1 = this.c
             e2 = this.d
             n1 = this.a

--- a/src/main/kotlin/Tetrahedron.kt
+++ b/src/main/kotlin/Tetrahedron.kt
@@ -10,7 +10,6 @@ data class Tetrahedron(var a: Point, var b: Point, var c: Point, var d: Point) {
         val bd = this.b.distance(this.d)
         val cd = this.c.distance(this.d)
 
-
         var longest: Double = ab
         if (ac > longest) longest = ac
         if (ad > longest) longest = ad
@@ -18,45 +17,54 @@ data class Tetrahedron(var a: Point, var b: Point, var c: Point, var d: Point) {
         if (bd > longest) longest = bd
         if (cd > longest) longest = cd
 
-        var e1: Point = this.a
-        var e2: Point = this.b
-        var n1: Point = this.c
-        var n2: Point = this.d
-        if (ac == longest) {
-            e1 = this.a
-            e2 = this.c
-            n1 = this.b
-            n2 = this.d
+        val e1: Point
+        val e2: Point
+        val n1: Point
+        val n2: Point
+
+        // In the case of identical sides, prefer reordering by checking CD first and AB last.
+        when (longest) {
+            cd -> {
+                e1 = this.c
+                e2 = this.d
+                n1 = this.a
+                n2 = this.b
+            }
+            bd -> {
+                e1 = this.b
+                e2 = this.d
+                n1 = this.a
+                n2 = this.c
+            }
+            bc -> {
+                e1 = this.b
+                e2 = this.c
+                n1 = this.a
+                n2 = this.d
+            }
+            ad -> {
+                e1 = this.a
+                e2 = this.d
+                n1 = this.b
+                n2 = this.c
+            }
+            ac -> {
+                e1 = this.a
+                e2 = this.c
+                n1 = this.b
+                n2 = this.d
+            }
+            else -> {
+                assert(ab == longest)
+                e1 = this.a
+                e2 = this.b
+                n1 = this.c
+                n2 = this.d
+            }
         }
 
-        if (ad == longest) {
-            e1 = this.a
-            e2 = this.d
-            n1 = this.b
-            n2 = this.c
-        }
-
-        if (bc == longest){
-            e1 = this.b
-            e2 = this.c
-            n1 = this.a
-            n2 = this.d
-        }
-
-        if (bd == longest){
-            e1 = this.b
-            e2 = this.d
-            n1 = this.a
-            n2 = this.c
-        }
-
-        if (cd == longest){
-            e1 = this.c
-            e2 = this.d
-            n1 = this.a
-            n2 = this.b
-        }
-        // TODO: It would be good to avoid needing side effects. Instead of reassignment, consider saving new reference.
+        // TODO: It would be good to avoid needing side effects. Instead of reassignment, consider
+        //   returning a new Tetrahedron instead.
         this.a = e1
         this.b = e2
         this.c = n1

--- a/src/test/kotlin/TestPlanet.kt
+++ b/src/test/kotlin/TestPlanet.kt
@@ -44,14 +44,14 @@ class GetElevationAtCoordinateTest {
     fun test_low_resolution(){
         val planet = Planet(seed=99987.0, resolution=100000)
         val elevation = planet.getElevationAt(lat=-10.0, lon=-43.0)
-        assertEquals(147.77922543048044, elevation)
+        assertEquals(-106.73954005463241, elevation)
     }
 
     @Test
     fun test_high_resolution(){
         val planet = Planet(seed=54399875.0, resolution=50)
         val elevation = planet.getElevationAt(lat=45.0, lon=23.0)
-        assertEquals(-39.31818838120323, elevation)
+        assertEquals(-100.57347147365873, elevation)
     }
 }
 
@@ -74,10 +74,10 @@ class GetMultipleElevationsTest {
 
         for (point in results){
             if (point.lat == -10.0) {
-                assertEquals(147.77922543048044, point.alt, 1.0E-7)
+                assertEquals(-106.73954005463241, point.alt, 1.0E-7)
             } else {
                 assertEquals(point.lat, 45.0)
-                assertEquals(-144.66142049532252, point.alt)
+                assertEquals(72.92436897719139, point.alt)
             }
         }
     }


### PR DESCRIPTION
A typo resulted in incorrect results from comparisons.
As well, prefer reordering in the case of multiple sides with the same length.